### PR TITLE
Extract out inline function for MoreOptionsIconContainer

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -137,10 +137,15 @@ export const InOutTextarea: FC<Props> = props => {
     boolean
   >(false);
 
-  const onOutMoreOptionsClick = useCallback(() => {
+  const onInMoreOptionsClick = useCallback(() => {
     setShowAdditionalOutOptions(false);
     setShowAdditionalInOptions(!showAdditionalInOptions);
   }, [showAdditionalInOptions]);
+
+  const onOutMoreOptionsClick = useCallback(() => {
+    setShowAdditionalInOptions(false);
+    setShowAdditionalOutOptions(!showAdditionalOutOptions);
+  }, [showAdditionalOutOptions]);
 
   const {
     inOptions,
@@ -179,7 +184,7 @@ export const InOutTextarea: FC<Props> = props => {
           </OptionsContainer>
           <MoreOptionsIconContainer
             ref={inOptionsMenuRef}
-            onClick={onOutMoreOptionsClick}
+            onClick={onInMoreOptionsClick}
           >
             {!showAdditionalInOptions && <IconChevronDown />}
             {showAdditionalInOptions && <IconChevronUp />}
@@ -213,10 +218,7 @@ export const InOutTextarea: FC<Props> = props => {
           <MoreOptionsIconContainer
             right
             ref={outOptionsMenuRef}
-            onClick={() => {
-              setShowAdditionalInOptions(false);
-              setShowAdditionalOutOptions(!showAdditionalOutOptions);
-            }}
+            onClick={onOutMoreOptionsClick}
           >
             {!showAdditionalOutOptions && <IconChevronDown />}
             {showAdditionalOutOptions && <IconChevronUp />}


### PR DESCRIPTION
Extract out an inline function for MoreOptionsIconContainer and fix function name typo.

Ref: https://github.com/igeligel/react-in-out-textarea/issues/47